### PR TITLE
feat: customize package and class name of generated object

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ class CreateUserAuditor implements AuditProcessor {
  class UserService {
      
      @Audit(processor = CreateUserAuditor.class)
-     @ParameterObject("CreateUserParameters") // processor generates parameter object from signature
+     @ParameterObject // processor generates parameter object from signature
      User createUser(String firstName, String lastName, List<Order> orders) {
          // do some work
      }
@@ -138,3 +138,19 @@ class CreateUserAuditor implements AuditProcessor {
   ``` 
 
 Annotate methods of your classes with `@ParameterObject` annotation.
+
+## Features
+
+### Customize parameter object class names
+
+By default the parameter object will be named by the pattern: `<ClassName><MethodName>Parameters`.
+It will reside in the same package as the class with an annotated method.
+
+To change name and/or package use:
+
+```java
+@ParameterObject(packageName="my.parameters", className="AwesomeParameters")
+void awesomeMethod(String message) {}
+```
+
+When any of the attributes missing the default strategy is applied to missing component.

--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -37,6 +37,31 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.8.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/annotation-processor/src/main/java/net/anatolich/parameterobject/ClassNameResolver.java
+++ b/annotation-processor/src/main/java/net/anatolich/parameterobject/ClassNameResolver.java
@@ -13,11 +13,35 @@ public class ClassNameResolver {
         this.elements = elements;
     }
 
-    public ClassName resolve(ExecutableElement method) {
+    public ClassName resolve(ExecutableElement method, ParameterObject annotation) {
+        return ClassName.get(
+            packageName(method, annotation),
+            className(method, annotation));
+    }
+
+    private String className(ExecutableElement method, ParameterObject annotation) {
+        if (StringUtils.isNotBlank(annotation.className())) {
+            return annotation.className();
+        } else {
+            return defaultClassName(method);
+        }
+    }
+
+    private String defaultClassName(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
         String className = method.getEnclosingElement().getSimpleName().toString();
-        String packageName = elements.getPackageOf(method.getEnclosingElement()).getQualifiedName().toString();
-        String poClassName = String.format("%s%sParameters", className, StringUtils.capitalize(methodName));
-        return ClassName.get(packageName, poClassName);
+        return String.format("%s%sParameters", className, StringUtils.capitalize(methodName));
+    }
+
+    private String packageName(ExecutableElement method, ParameterObject annotation) {
+        if (StringUtils.isNotBlank(annotation.packageName())) {
+            return annotation.packageName();
+        } else {
+            return defaultPackageName(method);
+        }
+    }
+
+    private String defaultPackageName(ExecutableElement method) {
+        return elements.getPackageOf(method.getEnclosingElement()).getQualifiedName().toString();
     }
 }

--- a/annotation-processor/src/main/java/net/anatolich/parameterobject/ParameterObjectAnnotationProcessor.java
+++ b/annotation-processor/src/main/java/net/anatolich/parameterobject/ParameterObjectAnnotationProcessor.java
@@ -40,7 +40,8 @@ public class ParameterObjectAnnotationProcessor extends AbstractProcessor {
         final Set<? extends Element> annotatedMethods = roundEnv.getElementsAnnotatedWith(ParameterObject.class);
         for (Element annotatedMethod : annotatedMethods) {
             final ExecutableElement method = (ExecutableElement) annotatedMethod;
-            final ClassName parametersClassName = classNameResolver.resolve(method);
+            final ClassName parametersClassName = classNameResolver
+                .resolve(method, method.getAnnotation(ParameterObject.class));
 
             final ParameterObjectClassBuilder parameterObjectClassBuilder =
                 new ParameterObjectClassBuilder(parametersClassName, method);

--- a/annotation-processor/src/test/java/net/anatolich/parameterobject/ClassNameResolverTest.java
+++ b/annotation-processor/src/test/java/net/anatolich/parameterobject/ClassNameResolverTest.java
@@ -1,0 +1,142 @@
+package net.anatolich.parameterobject;
+
+import com.squareup.javapoet.ClassName;
+import java.lang.annotation.Annotation;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ClassNameResolverTest {
+
+    private ClassNameResolver classNameResolver;
+    private Elements elements;
+
+    @BeforeEach
+    void createResolver() {
+        elements = Mockito.mock(Elements.class);
+        classNameResolver = new ClassNameResolver(elements);
+    }
+
+    @Test
+    void resolveDefaultName() {
+        String methodName = "method";
+        String className = "Class";
+        String packageName = "net.anatolich.util";
+        ClassName resolvedName = classNameResolver.resolve(methodElement(methodName, className, packageName),
+            annotation(null, null));
+
+        Assertions.assertThat(resolvedName.packageName())
+            .isEqualTo(packageName);
+        Assertions.assertThat(resolvedName.simpleName())
+            .isEqualTo("ClassMethodParameters");
+    }
+
+    @Test
+    void resolveClassNameWithCustomPackage() {
+        String methodName = "method";
+        String className = "Class";
+        String packageName = "net.anatolich.util";
+        String customPackageName = "custom.util";
+
+        ClassName resolvedName = classNameResolver.resolve(
+            methodElement(methodName, className, packageName),
+            annotation(customPackageName, null)
+        );
+
+        Assertions.assertThat(resolvedName.packageName())
+            .as("annotation overrides default package")
+            .isEqualTo(customPackageName);
+        Assertions.assertThat(resolvedName.simpleName())
+            .isEqualTo("ClassMethodParameters");
+    }
+
+    @Test
+    void resolveClassNameWithCustomClassName() {
+        String methodName = "method";
+        String className = "Class";
+        String packageName = "net.anatolich.util";
+        String customClassName = "AwesomeParameters";
+
+        ClassName resolvedName = classNameResolver.resolve(
+            methodElement(methodName, className, packageName),
+            annotation(null, customClassName)
+        );
+
+        Assertions.assertThat(resolvedName.packageName())
+            .as("annotation overrides default package")
+            .isEqualTo(packageName);
+        Assertions.assertThat(resolvedName.simpleName())
+            .isEqualTo(customClassName);
+    }
+
+    private ExecutableElement methodElement(String methodName, String className, String packageName) {
+        final ExecutableElement methodElementMock = Mockito.mock(ExecutableElement.class);
+        final TypeElement classElementMock = Mockito.mock(TypeElement.class);
+        final PackageElement packageElementMock = Mockito.mock(PackageElement.class);
+        Mockito.when(methodElementMock.getSimpleName()).thenReturn(new SimpleName(methodName));
+        Mockito.when(methodElementMock.getEnclosingElement()).thenReturn(classElementMock);
+        Mockito.when(classElementMock.getSimpleName()).thenReturn(new SimpleName(className));
+        Mockito.when(elements.getPackageOf(Mockito.any())).thenReturn(packageElementMock);
+        Mockito.when(packageElementMock.getQualifiedName()).thenReturn(new SimpleName(packageName));
+        return methodElementMock;
+    }
+
+    private static class SimpleName implements Name {
+
+        private final String value;
+
+        private SimpleName(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean contentEquals(CharSequence cs) {
+            return value.contentEquals(cs);
+        }
+
+        @Override
+        public int length() {
+            return value.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return value.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return value.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    private ParameterObject annotation(String packageName, String className) {
+        return new ParameterObject() {
+            @Override
+            public String packageName() {
+                return (packageName == null) ? "" : packageName;
+            }
+
+            @Override
+            public String className() {
+                return (className == null) ? "" : className;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ParameterObject.class;
+            }
+        };
+    }
+}

--- a/annotation/src/main/java/net/anatolich/parameterobject/ParameterObject.java
+++ b/annotation/src/main/java/net/anatolich/parameterobject/ParameterObject.java
@@ -11,4 +11,14 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface ParameterObject {
 
+    /**
+     * Desired package name. If not specified the parameter object will be in the same package
+     * as annotated class.
+     */
+    String packageName() default "";
+
+    /**
+     * Desired class name. If not specified then default class name generation strategy will be applied.
+     */
+    String className() default "";
 }


### PR DESCRIPTION
`@ParameterObject` annotation got attributes to customize both package and class name of a generated class.

```java
@ParameterObject(packageName="custom.utils", className="AwesomeParameters")
```